### PR TITLE
push to new artifact registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           registry: europe-west4-docker.pkg.dev
           username: _json_key
-          password: ${{ secrets.VELO_ACTION_GSA_KEY_JSON_PROD }}
+          password: ${{ secrets.VELO_ACTION_GSA_KEY_PROD_PUBLIC }}
 
       - uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-20.04
+    name: Lint
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -39,6 +40,7 @@ jobs:
 
   test:
     runs-on: ubuntu-20.04
+    name: Test
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: push
 
 env:
-  IMAGE: odacom/velo-action
+  IMAGE: europe-west4-docker.pkg.dev/nube-artifacts/nube-docker-public/velo-action
 
 jobs:
   lint:
@@ -66,18 +66,12 @@ jobs:
       # - run: poetry run pytest . -c pytest.ini --capture=no -v -m "not docker"
       #   id: pytests
 
-  ci-done:
-    name: CI done
-    runs-on: ubuntu-20.04
-    needs:
-      - lint
-      - test
-    steps:
-      - run: echo "CI done!"
-
-  build_and_push:
+  build:
     runs-on: ubuntu-20.04
     name: Build & push
+    needs:
+      - "lint"
+      - "test"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -86,32 +80,18 @@ jobs:
       - uses: ./
         id: velo
 
-      - run: |
-          docker build -t "${{ env.IMAGE }}:${{ steps.velo.outputs.version }}" .
-          docker tag "${{ env.IMAGE }}:${{ steps.velo.outputs.version }}" ${{ env.IMAGE }}:latest
+      - uses: docker/setup-buildx-action@v1
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: europe-west4-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.VELO_ACTION_GSA_KEY_JSON_PROD }}
 
-      - name: Wait on lint and test
-        uses: lewagon/wait-on-check-action@v0.2
+      - uses: docker/build-push-action@v2
         with:
-          ref: ${{ github.ref }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
-          running-workflow-name: build_and_push
-          check-name: CI done
-
-      - run: |
-          docker push --all-tags ${{ env.IMAGE }}
-
-  ci_build_done:
-    name: Build done
-    runs-on: ubuntu-20.04
-    needs:
-      - build_and_push
-    steps:
-      - run: echo "Build image and pushed!"
+          context: .
+          push: true
+          tags: ${{ env.IMAGE }}:${{ steps.velo.outputs.version }},${{ env.IMAGE }}:latest
+          cache-from: type=registry
+          cache-to: type=registry

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ outputs:
       Version used to crate release and tag image.
 runs:
   using: docker
-  image: docker://odacom/velo-action:latest
+  image: Dockerfile
   args:
     - ${{ inputs.version }}
     - ${{ inputs.create_release }}


### PR DESCRIPTION
use new artifact registry in gcp, https://console.cloud.google.com/artifacts?organizationId=429860418237&project=nube-artifacts


push to the public registry, the public registry is required for github action to work.