### PR TITLE
Hotfix: Interact with octopus using subprocess.run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ tests:
 	poetry run pytest tests -c pytest.ini -v -m "not docker"
 
 image:
-	docker build -t europe-docker.pkg.dev/nube-artifacts-prod/nube-container-images-public/velo-action:${VERSION} .
+	docker build -t europe-docker.pkg.dev/nube-hub/docker-public/velo-action:${VERSION} .
 
 push:
-	docker push europe-docker.pkg.dev/nube-artifacts-prod/nube-container-images-public/velo-action:${VERSION}
+	docker push europe-docker.pkg.dev/nube-hub/docker-public/velo-action:${VERSION}
 
 run: image
 	docker-compose run --rm velo-action

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ tests:
 	poetry run pytest tests -c pytest.ini -v -m "not docker"
 
 image:
-	docker build -t europe-docker.pkg.dev/nube-artifacts-prod/nube-container-images-public/velo-action:$(gitversion /showvariable SemVer) .
+	docker build -t europe-docker.pkg.dev/nube-artifacts-prod/nube-container-images-public/velo-action:${VERSION} .
 
 push:
-	docker push europe-docker.pkg.dev/nube-artifacts-prod/nube-container-images-public/velo-action:$(gitversion /showvariable SemVer)
+	docker push europe-docker.pkg.dev/nube-artifacts-prod/nube-container-images-public/velo-action:${VERSION}
 
 run: image
 	docker-compose run --rm velo-action

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ outputs:
       Version used to crate release and tag image.
 runs:
   using: docker
-  image: docker://europe-docker.pkg.dev/nube-hub/docker-public/velo-action:0.2.79-RmMsr-try-subprocess-run.4
+  image: docker://europe-docker.pkg.dev/nube-hub/docker-public/velo-action:0.2.79-RmMsr-try-subprocess-run.6
   args:
     - ${{ inputs.version }}
     - ${{ inputs.create_release }}

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ outputs:
       Version used to crate release and tag image.
 runs:
   using: docker
-  image: docker://europe-docker.pkg.dev/nube-hub/docker-public/velo-action:0.2.72
+  image: docker://europe-docker.pkg.dev/nube-hub/docker-public/velo-action:0.2.78
   args:
     - ${{ inputs.version }}
     - ${{ inputs.create_release }}

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ outputs:
       Version used to crate release and tag image.
 runs:
   using: docker
-  image: docker://europe-docker.pkg.dev/nube-hub/docker-public/velo-action:0.2.79-RmMsr-try-subprocess-run.10
+  image: docker://europe-docker.pkg.dev/nube-hub/docker-public/velo-action:0.2.79
   args:
     - ${{ inputs.version }}
     - ${{ inputs.create_release }}

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ outputs:
       Version used to crate release and tag image.
 runs:
   using: docker
-  image: docker://europe-docker.pkg.dev/nube-hub/docker-public/velo-action:0.2.78
+  image: docker://europe-docker.pkg.dev/nube-hub/docker-public/velo-action:0.2.79-RmMsr-try-subprocess-run.2
   args:
     - ${{ inputs.version }}
     - ${{ inputs.create_release }}

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ outputs:
       Version used to crate release and tag image.
 runs:
   using: docker
-  image: docker://europe-docker.pkg.dev/nube-hub/docker-public/velo-action:0.2.79-RmMsr-try-subprocess-run.8
+  image: docker://europe-docker.pkg.dev/nube-hub/docker-public/velo-action:0.2.79-RmMsr-try-subprocess-run.10
   args:
     - ${{ inputs.version }}
     - ${{ inputs.create_release }}

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ outputs:
       Version used to crate release and tag image.
 runs:
   using: docker
-  image: docker://europe-docker.pkg.dev/nube-hub/docker-public/velo-action:0.2.79-RmMsr-try-subprocess-run.6
+  image: docker://europe-docker.pkg.dev/nube-hub/docker-public/velo-action:0.2.79-RmMsr-try-subprocess-run.8
   args:
     - ${{ inputs.version }}
     - ${{ inputs.create_release }}

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ outputs:
       Version used to crate release and tag image.
 runs:
   using: docker
-  image: docker://europe-docker.pkg.dev/nube-hub/docker-public/velo-action:0.2.79-RmMsr-try-subprocess-run.2
+  image: docker://europe-docker.pkg.dev/nube-hub/docker-public/velo-action:0.2.79-RmMsr-try-subprocess-run.4
   args:
     - ${{ inputs.version }}
     - ${{ inputs.create_release }}

--- a/velo_action/octopus.py
+++ b/velo_action/octopus.py
@@ -59,7 +59,7 @@ class Octopus:
         return tenant_names
 
     def list_releases(self, project):
-        cmd = f"octo list-releases --project={project} --outputformat=json"
+        cmd = ["octo", "list-releases", "--project={project}", "--outputformat=json"]
         result = proc_utils.execute_process_sp_run(
             cmd, env_vars=self.octa_env_vars, log_stdout=False, log_cmd=False
         )

--- a/velo_action/octopus.py
+++ b/velo_action/octopus.py
@@ -59,9 +59,9 @@ class Octopus:
         return tenant_names
 
     def list_releases(self, project):
-        cmd = ["octo", "list-releases", "--project={project}", "--outputformat=json"]
+        cmd = f"octo list-releases --project={project} --outputformat=json"
         result = proc_utils.execute_process_sp_run(
-            cmd, self.octa_env_vars, log_stdout=False, log_cmd=False
+            cmd, env_vars=self.octa_env_vars, log_stdout=False, log_cmd=False
         )
         releases_list = json.loads("".join(result))
         releases = releases_list[0].get("Releases")

--- a/velo_action/octopus.py
+++ b/velo_action/octopus.py
@@ -52,7 +52,7 @@ class Octopus:
     def list_tenants(self):
         cmd = ("octo", "list-tenants", "--outputformat=json")
         result = proc_utils.execute_process_sp_run(
-            cmd, self.octa_env_vars, log_cmd=False, log_stdout=False
+            cmd, env_vars=self.octa_env_vars, log_cmd=False, log_stdout=False
         )
         tenants_list = json.loads(result)
         tenant_names = [o.get("Name") for o in tenants_list]
@@ -87,7 +87,7 @@ class Octopus:
                 "--helpOutputFormat=Json",
             )
             proc_utils.execute_process_sp_run(
-                cmd, self.octa_env_vars, log_stdout=True, forward_stdout=False
+                cmd, env_vars=self.octa_env_vars, log_stdout=True, forward_stdout=False
             )
 
     def deploy_release(

--- a/velo_action/octopus.py
+++ b/velo_action/octopus.py
@@ -60,7 +60,7 @@ class Octopus:
 
     def list_releases(self, project):
         cmd = f"octo list-releases --project={project} --outputformat=json"
-        result = proc_utils.execute_process(
+        result = proc_utils.execute_process_sp_run(
             cmd, self.octa_env_vars, log_stdout=False, log_cmd=False
         )
         releases_list = json.loads("".join(result))

--- a/velo_action/octopus.py
+++ b/velo_action/octopus.py
@@ -59,7 +59,7 @@ class Octopus:
         return tenant_names
 
     def list_releases(self, project):
-        cmd = f"octo list-releases --project={project} --outputformat=json"
+        cmd = ["octo", "list-releases", "--project={project}", "--outputformat=json"]
         result = proc_utils.execute_process_sp_run(
             cmd, self.octa_env_vars, log_stdout=False, log_cmd=False
         )

--- a/velo_action/octopus.py
+++ b/velo_action/octopus.py
@@ -22,8 +22,8 @@ class Octopus:
 
         # test connection to server
         try:
-            proc_utils.execute_process(
-                "octo list-environments",
+            proc_utils.execute_process_sp_run(
+                ("octo", "list-environments"),
                 log_cmd=False,
                 env_vars=self.octa_env_vars,
                 log_stdout=False,
@@ -35,7 +35,7 @@ class Octopus:
 
     def _octo_cli_exists(self):
         try:
-            proc_utils.execute_process("octo", log_cmd=False, log_stdout=False)
+            proc_utils.execute_process_sp_run("octo", log_cmd=False, log_stdout=False)
         except:
             raise Exception(
                 "Octopus Cli 'octo' is not installed. See https://octopus.com/downloads/octopuscli for instructions"
@@ -43,27 +43,27 @@ class Octopus:
         return True
 
     def _version(self):
-        result = proc_utils.execute_process(
-            "octo --version", log_cmd=False, log_stdout=False
+        result = proc_utils.execute_process_sp_run(
+            ("octo", "--version"), log_cmd=False, log_stdout=False
         )
         version = result[0]
         return version
 
     def list_tenants(self):
-        cmd = "octo list-tenants --outputformat=json"
-        result = proc_utils.execute_process(
+        cmd = ("octo", "list-tenants", "--outputformat=json")
+        result = proc_utils.execute_process_sp_run(
             cmd, self.octa_env_vars, log_cmd=False, log_stdout=False
         )
-        tenants_list = json.loads("".join(result))
+        tenants_list = json.loads(result)
         tenant_names = [o.get("Name") for o in tenants_list]
         return tenant_names
 
     def list_releases(self, project):
-        cmd = ["octo", "list-releases", "--project={project}", "--outputformat=json"]
+        cmd = ("octo", "list-releases", f"--project={project}", "--outputformat=json")
         result = proc_utils.execute_process_sp_run(
             cmd, env_vars=self.octa_env_vars, log_stdout=False, log_cmd=False
         )
-        releases_list = json.loads("".join(result))
+        releases_list = json.loads(result)
         releases = releases_list[0].get("Releases")
         return releases
 
@@ -79,14 +79,14 @@ class Octopus:
 
         if not exists:
             cmd = (
-                "octo"
-                " create-release"
-                f" --version={version}"
-                f" --project={project}"
-                f" --releaseNotes={shlex.quote(json.dumps(release_note_dict))}"
-                " --helpOutputFormat=Json"
+                "octo",
+                "create-release",
+                f"--version={version}",
+                f"--project={project}",
+                f"--releaseNotes={shlex.quote(json.dumps(release_note_dict))}",
+                "--helpOutputFormat=Json",
             )
-            proc_utils.execute_process(
+            proc_utils.execute_process_sp_run(
                 cmd, self.octa_env_vars, log_stdout=True, forward_stdout=False
             )
 
@@ -106,11 +106,16 @@ class Octopus:
         if wait_for_deployment:
             args.append("--waitForDeployment")
 
-        cmd = (
-            f"octo deploy-release --project={project} --version={version} "
-            f'--deployTo={environment} --variable="GithubSpanID:{started_span_id}"'
-        )
-        cmd = cmd + " " + " ".join(str(x) for x in args)
+        cmd = [
+            "octo",
+            "deploy-release",
+            f"--project={project}",
+            f"--version={version}",
+            f"--deployTo={environment}",
+            f'--variable="GithubSpanID:{started_span_id}"',
+        ]
+        cmd = cmd + args
+
         if tenants:
             octo_tenants = self.list_tenants()
             for tenant in tenants:
@@ -119,9 +124,8 @@ class Octopus:
                         f"Tenant '{tenant}' does not exist in Octopus Deploy, found '{octo_tenants}'."
                     )
 
-                cmd_tenant = f"--tenant={tenant}"
-                proc_utils.execute_process(
-                    cmd + " " + cmd_tenant,
+                proc_utils.execute_process_sp_run(
+                    cmd + [f"--tenant={tenant}"],
                     env_vars=self.octa_env_vars,
                     log_stdout=True,
                     forward_stdout=False,
@@ -130,7 +134,7 @@ class Octopus:
                     f"Deploying '{project}' '{tenant}' version '{version}' to '{environment}'"
                 )
         else:
-            proc_utils.execute_process(
+            proc_utils.execute_process_sp_run(
                 cmd, env_vars=self.octa_env_vars, log_stdout=True, forward_stdout=False
             )
             logger.info(f"Deploying '{project}' version '{version}' to '{environment}'")

--- a/velo_action/proc_utils.py
+++ b/velo_action/proc_utils.py
@@ -18,6 +18,44 @@ def ansi_escape_string(input_str):
     return ansi_escape.sub("", input_str)
 
 
+def execute_process_sp_run(
+    args,
+    *,
+    env_vars=None,
+    fail_on_non_zero_exit=True,
+    log_cmd=True,
+    log_envvars=False,
+    log_stdout=True,
+    forward_stdout=False,
+    log_stderr=True,
+    cwd=None,
+):
+    if not env_vars:
+        env_vars = {}
+    proc_env_vars = os.environ.copy()
+    proc_env_vars = {**proc_env_vars, **env_vars}
+    if log_cmd:
+        logger.info(f"Running '{args}'")
+    if log_envvars:
+        logger.info("Env Vars")
+        logger.info(proc_env_vars)
+
+    process_output = subprocess.run(
+        args,
+        env=proc_env_vars,
+        cwd=cwd,
+        capture_output=not forward_stdout,
+        check=fail_on_non_zero_exit,
+    )
+
+    if not forward_stdout and log_stdout:
+        logger.info(f"stdout logs for command '{args}'")
+        logger.info(process_output.stdout.decode(encoding="utf-8"))
+    if not forward_stdout and log_stderr:
+        logger.info(f"stderr logs for command '{args}'")
+        logger.info(process_output.stderr.decode(encoding="utf-8"))
+
+
 def execute_process(
     cmd,
     env_vars=None,

--- a/velo_action/proc_utils.py
+++ b/velo_action/proc_utils.py
@@ -55,6 +55,8 @@ def execute_process_sp_run(
         logger.info(f"stderr logs for command '{args}'")
         logger.info(process_output.stderr.decode(encoding="utf-8"))
 
+    return process_output.stdout
+
 
 def execute_process(
     cmd,

--- a/velo_action/settings.py
+++ b/velo_action/settings.py
@@ -10,7 +10,7 @@ class Settings(BaseSettings):
     """[Parse input arguments]
 
     The Github action only provides input arguments to the container as environment variables,
-    with INPUT_ prefiex on the argument name.
+    with INPUT_ prefix on the argument name.
 
     This means every argument is parsed as a string.
     To replicate this behaviour when debugging locally all default values is also set to the string 'None'.


### PR DESCRIPTION
We see some errors when creating releases. Probably due to bigger payloads when getting the list of releases from octopus deploy. As in https://github.com/kolonialno/velo/pull/183 using `subprocess.run()` should improve the situation.