### PR TITLE
Allow to deploy if release exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2022-04-25
+
+### Changed
+
+Fix bug preventing deploys of existing releases in Octopus Deploy. If a release exist, do not recreate it, but do perform the deploys as specified in `deploy_to_environments`.
+
 ## [1.0.0] - 2022-04-20
 
 ### Added

--- a/velo_action/main.py
+++ b/velo_action/main.py
@@ -84,30 +84,30 @@ def action(
                 "Project -> Releases -> <Select Release> -> : menu in top right corner -> Delete. "
                 "Skipping..."
             )
-            return None
 
-        files = gcloud.upload_from_directory(
-            path=deploy_folder,
-            dest_bucket_name=velo_artifact_bucket,
-            dest_blob_name=f"{velo_settings.project}/{args.version}",
-        )
+        else:
+            files = gcloud.upload_from_directory(
+                path=deploy_folder,
+                dest_bucket_name=velo_artifact_bucket,
+                dest_blob_name=f"{velo_settings.project}/{args.version}",
+            )
 
-        logger.info(
-            f"Uploaded {len(files)} release files to "
-            f"'https://console.cloud.google.com/storage/browser/{velo_artifact_bucket}/{velo_settings.project}/{args.version}'"
-        )
+            logger.info(
+                f"Uploaded {len(files)} release files to "
+                f"'https://console.cloud.google.com/storage/browser/{velo_artifact_bucket}/{velo_settings.project}/{args.version}'"
+            )
 
-        logger.info(
-            f"Creating a release in Octopus Deploy for project '{velo_settings.project}' with version '{args.version}'"
-        )
-        release.create(
-            project_name=velo_settings.project,
-            project_version=args.version,
-            github_settings=github_settings,
-        )
-        logger.info(
-            f"See {release.client.baseurl}/app#/Spaces-1/projects/{velo_settings.project}/deployments/releases/{args.version}"
-        )
+            logger.info(
+                f"Creating a release in Octopus Deploy for project '{velo_settings.project}' with version '{args.version}'"
+            )
+            release.create(
+                project_name=velo_settings.project,
+                project_version=args.version,
+                github_settings=github_settings,
+            )
+            logger.info(
+                f"See {release.client.baseurl}/app#/Spaces-1/projects/{velo_settings.project}/deployments/releases/{args.version}"
+            )
 
     if args.deploy_to_environments:
         logger.info(f"Deploy to environments: {args.deploy_to_environments}")

--- a/velo_action/main.py
+++ b/velo_action/main.py
@@ -71,11 +71,14 @@ def action(
     octo = OctopusClient(server=octopus_server, api_key=octopus_api_key)
     if args.create_release:
         release = Release(client=octo)
+
         velo_settings = read_velo_settings(deploy_folder)
 
-        if release.exists(
+        release_exists = release.exists(
             project_name=velo_settings.project, version=args.version, client=octo
-        ):
+        )
+
+        if release_exists:
             logger.info(
                 f"Release '{args.version}' already exists at "
                 f"'{release.client.baseurl}/app#/Spaces-1/projects/"
@@ -84,7 +87,6 @@ def action(
                 "Project -> Releases -> <Select Release> -> : menu in top right corner -> Delete. "
                 "Skipping..."
             )
-
         else:
             files = gcloud.upload_from_directory(
                 path=deploy_folder,
@@ -94,7 +96,8 @@ def action(
 
             logger.info(
                 f"Uploaded {len(files)} release files to "
-                f"'https://console.cloud.google.com/storage/browser/{velo_artifact_bucket}/{velo_settings.project}/{args.version}'"
+                "'https://console.cloud.google.com/storage/browser/"
+                f"{velo_artifact_bucket}/{velo_settings.project}/{args.version}'"
             )
 
             logger.info(


### PR DESCRIPTION
## Describe your changes

Fix bug preventing a deploy if the release already exists.


## How to release

Each PR merged to `main` will create a new draft release.

All notable changes to this project shall be documented in the [CHANGELOG.md](../CHANGELOG.md).
The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).

This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
Determine the version of the current release by running `make verison`.
Bump version if nececary according by adding this to the commit message `+semver: major`, `+semver: minor`.

- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md).
- [x] I have bumped the version if neccecary.
