### PR TITLE
do not fail to generate version even if service_account_key input is not set

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -64,6 +64,8 @@ jobs:
     steps:
       - name: Checkout velo-action repo
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Generate version
         uses: ./.github/actions/gitversion
@@ -73,6 +75,14 @@ jobs:
         uses: mikefarah/yq@v4.24.2
         with:
           cmd: yq -i '.runs.image = "docker://europe-docker.pkg.dev/nube-hub/docker-public/velo-action:${{ steps.gitversion.outputs.version }}"' action.yml
+
+      - name: Test generate version
+        uses: ./  # Use action.yml in root
+        id: test_version
+
+      - name: Verify version
+        run:
+          test "${{ steps.test_version.outputs.version }}"=="$(git rev-parse --short HEAD)"
 
       - name: Run e2e test - create a release for velo-action
         uses: ./  # Use action.yml in root

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -101,6 +101,7 @@ jobs:
 
       - name: Test deploy to environment when a release exist
         uses: ./  # Use action.yml in root
+        if: ${{ !github.event.pull_request.draft }}  # Test is slow since it performs a deploy. Do not run when in draft PR.
         with:
           create_release: 'True'
           deploy_to_environments: staging

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -82,12 +82,22 @@ jobs:
 
       - name: Verify version
         run:
-          test "${{ steps.test_version.outputs.version }}"=="$(git rev-parse --short HEAD)"
+          if [[ "${{ steps.test_version.outputs.version }}"!="$(git rev-parse --short HEAD)"]]; then
+            exit(1)
+          fi
 
-      - name: Run e2e test - create a release for velo-action
+      - name: Test create a release
         uses: ./  # Use action.yml in root
         with:
           create_release: 'True'
+          version: ${{ steps.gitversion.outputs.version }}
+          service_account_key: ${{ secrets.VELO_ACTION_GSA_KEY_PROD_PUBLIC }}
+
+      - name: Test deploy to environment when a release exist
+        uses: ./  # Use action.yml in root
+        with:
+          create_release: 'True'
+          deploy_to_environments: staging
           version: ${{ steps.gitversion.outputs.version }}
           service_account_key: ${{ secrets.VELO_ACTION_GSA_KEY_PROD_PUBLIC }}
 

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -81,9 +81,13 @@ jobs:
         id: test_version
 
       - name: Verify version
-        run:
-          if [[ "${{ steps.test_version.outputs.version }}"!="$(git rev-parse --short HEAD)"]]; then
-            exit(1)
+        shell: bash
+        run: |
+          git_ref=$(git rev-parse --short HEAD)
+
+          if [[ "${{ steps.test_version.outputs.version }}" != "$git_ref" ]]; then
+              echo "Version is not correct."
+              exit 1
           fi
 
       - name: Test create a release

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -88,6 +88,8 @@ jobs:
           if [[ "${{ steps.test_version.outputs.version }}" != "$git_ref" ]]; then
               echo "Version is not correct."
               exit 1
+          else
+            echo "Version is correct."
           fi
 
       - name: Test create a release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2022-04-26
+
+Fix bug preventing the action to output the generated version if `service_account_key` input is not set.
+
 ## [1.0.1] - 2022-04-25
 
 ### Changed

--- a/velo_action/main.py
+++ b/velo_action/main.py
@@ -85,7 +85,6 @@ def action(  # pylint: disable=too-many-branches
                 f"{velo_settings.project}/deployments/releases/{args.version}'. "
                 "If you want to recreate this release, please delete it first in Octopus Deploy."
                 "Project -> Releases -> <Select Release> -> : menu in top right corner -> Delete. "
-                "Skipping..."
             )
         else:
             files = gcloud.upload_from_directory(

--- a/velo_action/main.py
+++ b/velo_action/main.py
@@ -54,10 +54,6 @@ def action(  # pylint: disable=too-many-branches
 
     os.chdir(args.workspace)  # type: ignore
 
-    if not args.create_release and not args.deploy_to_environments:
-        logger.warning("Nothing to do. Exciting now.")
-        return None
-
     if args.create_release or args.deploy_to_environments:
         gcloud = gcp.GCP(
             project=args.velo_project, service_account_key=args.service_account_key
@@ -144,14 +140,13 @@ def action(  # pylint: disable=too-many-branches
                     variables=deploy_vars,
                 )
 
-    if init_trace:
+    if init_trace and (args.deploy_to_environments or args.create_release):
         print_trace_link(span)
 
     # Set outputs in environment to be used by other
     # steps in the Github Action Workflows
     logger.info("Github actions outputs:")
     github.actions_output("version", args.version)
-    return None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Describe your changes

Fix a bug where running 

```
      - name: Generate version
        uses: kolonialno/velo-action@v1.0.1
        id: velo
```

fails since the action tries to fetch secrets when the `service_account_key` arg is not set.

The action should still generate and output version with success.

## How to release

Each PR merged to `main` will create a new draft release.

All notable changes to this project shall be documented in the [CHANGELOG.md](../CHANGELOG.md).
The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).

This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
Determine the version of the current release by running `make verison`.
Bump version if nececary according by adding this to the commit message `+semver: major`, `+semver: minor`.

- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md).
- [x] I have bumped the version if neccecary.
