### PR TITLE
ci: remove token due to removed pre-commit push

### DIFF
--- a/.github/workflows/lint-pre-commit.yml
+++ b/.github/workflows/lint-pre-commit.yml
@@ -28,5 +28,4 @@ jobs:
       - uses: pre-commit/action@v3.0.0
         name: ${{ matrix.id }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           extra_args: ${{ matrix.id }}


### PR DESCRIPTION
See #145 with removed support for pushing changes.